### PR TITLE
:sparkles: Add kuma config

### DIFF
--- a/src/commands/config/config.py
+++ b/src/commands/config/config.py
@@ -1,0 +1,100 @@
+import os
+
+
+def config(args):
+    print(
+        """
+                 _  __                      _____                                  _             
+                | |/ /                     / ____|                                (_)            
+                | ' /_   _ _ __ ___   __ _| |     ___  _ __ ___  _ __   __ _ _ __  _  ___  _ __  
+                |  <| | | | '_ ` _ \ / _` | |    / _ \| '_ ` _ \| '_ \ / _` | '_ \| |/ _ \| '_ \ 
+                | . \ |_| | | | | | | (_| | |___| (_) | | | | | | |_) | (_| | | | | | (_) | | | |
+                |_|\_\__,_|_| |_| |_|\__,_|\_____\___/|_| |_| |_| .__/ \__,_|_| |_|_|\___/|_| |_|
+                                                                | |                              
+                                                                |_|                                               
+
+          """
+    )
+    print("Version: " + os.environ["VERSION"])
+    print("Github: https://github.com/Zerka/KumaCompanion")
+    print("")
+
+    if args.show:
+        print_configuration()
+    else:
+        if args.url and args.username and args.password:
+            # Set the environment variables
+            os.environ["UPTIME_KUMA_URL"] = args.url
+            os.environ["UPTIME_KUMA_USERNAME"] = args.username
+            os.environ["UPTIME_KUMA_PASSWORD"] = args.password
+
+            print(
+                "Configuration completed. Your credentials have been stored in environment variables."
+            )
+        else:
+            print(
+                "Welcome to KumaCompanion configuration!\n"
+                "Please provide the following information to configure your Uptime Kuma instance:\n"
+            )
+
+            try:
+                url = input("Uptime Kuma API URL: ")
+                username = input("Username: ")
+                password = input("Password: ")
+            except (KeyboardInterrupt, EOFError):
+                print("\n\nConfiguration aborted.")
+                return
+
+            # Set the environment variables
+            os.environ["UPTIME_KUMA_URL"] = url
+            os.environ["UPTIME_KUMA_USERNAME"] = username
+            os.environ["UPTIME_KUMA_PASSWORD"] = password
+
+            print(
+                "Configuration completed. Your credentials have been stored in environment variables."
+            )
+
+
+def print_configuration():
+    print("Current Configuration:")
+    print(f"Uptime Kuma API URL: {os.environ.get('UPTIME_KUMA_URL', 'Not set')}")
+    print(f"Username: {os.environ.get('UPTIME_KUMA_USERNAME', 'Not set')}")
+    print(f"Password: {os.environ.get('UPTIME_KUMA_PASSWORD', 'Not set')}")
+
+
+def add_subparser(subparsers):
+    config_parser = subparsers.add_parser(
+        "config",  # name of the command
+        aliases=["cfg", "conf"],  # aliases of the command
+        help="Configure KumaCompanion",
+    )
+
+    config_parser.add_argument(
+        "--show",
+        help="Show current configuration",
+        required=False,
+        action="store_true",
+    )
+
+    config_parser.add_argument(
+        "--url",
+        help="Set the API URL",
+        required=False,
+    )
+
+    config_parser.add_argument(
+        "-u",
+        "--username",
+        help="Set the username",
+        required=False,
+    )
+
+    config_parser.add_argument(
+        "-p",
+        "--password",
+        help="Set the password",
+        required=False,
+    )
+
+    # Default action when no subcommand is provided
+    config_parser.set_defaults(func=config)

--- a/src/commands/config/config.py
+++ b/src/commands/config/config.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 
 def config(args):
@@ -15,7 +16,7 @@ def config(args):
 
           """
     )
-    print("Version: " + os.environ["VERSION"])
+    print("Version: 1.0.0")
     print("Github: https://github.com/Zerka/KumaCompanion")
     print("")
 
@@ -28,8 +29,14 @@ def config(args):
             os.environ["UPTIME_KUMA_USERNAME"] = args.username
             os.environ["UPTIME_KUMA_PASSWORD"] = args.password
 
+            # Update the .bashrc file
+            update_bashrc()
+
             print(
                 "Configuration completed. Your credentials have been stored in environment variables."
+            )
+            print(
+                "Please reload your shell to use the new configuration or run 'source ~/.bashrc'"
             )
         else:
             print(
@@ -50,9 +57,48 @@ def config(args):
             os.environ["UPTIME_KUMA_USERNAME"] = username
             os.environ["UPTIME_KUMA_PASSWORD"] = password
 
+            # Update the .bashrc file
+            update_bashrc()
+
             print(
-                "Configuration completed. Your credentials have been stored in environment variables."
+                "\nConfiguration completed. Your credentials have been stored in environment variables."
             )
+            print(
+                "Please reload your shell to use the new configuration or run 'source ~/.bashrc'"
+            )
+
+
+def update_bashrc():
+    # Get the current user's home directory
+    home_dir = os.path.expanduser("~")
+
+    # Generate the lines to be added to the .bashrc file
+    lines = [
+        f'export UPTIME_KUMA_URL="{os.environ["UPTIME_KUMA_URL"]}"\n',
+        f'export UPTIME_KUMA_USERNAME="{os.environ["UPTIME_KUMA_USERNAME"]}"\n',
+        f'export UPTIME_KUMA_PASSWORD="{os.environ["UPTIME_KUMA_PASSWORD"]}"\n',
+    ]
+
+    # Remove old configuration lines from the .bashrc file
+    with open(f"{home_dir}/.bashrc", "r") as f:
+        bashrc_content = f.readlines()
+
+    with open(f"{home_dir}/.bashrc", "w") as f:
+        for line in bashrc_content:
+            if not any(
+                variable in line
+                for variable in [
+                    "UPTIME_KUMA_URL",
+                    "UPTIME_KUMA_USERNAME",
+                    "UPTIME_KUMA_PASSWORD",
+                ]
+            ):
+                f.write(line)
+
+        f.writelines(lines)
+
+    # Source the updated .bashrc file to load the environment variables
+    subprocess.run(f"source {home_dir}/.bashrc", shell=True, executable="/bin/bash")
 
 
 def print_configuration():

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import argparse
 from commands.monitor import monitor
 from commands.maintenance import maintenance
+from commands.config import config
 
 
 def main():
@@ -10,6 +11,7 @@ def main():
     # Add subparsers for each top-level command
     monitor.add_subparser(subparsers)
     maintenance.add_subparser(subparsers)
+    config.add_subparser(subparsers)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
:sparkles: Added `kuma config` with 2 ways to configure. 

- Specify url, username and password with: `--url`, `-u`, `-p`.

- Specify nothing, and an interactive menu will be displayed to fill in the necessary information.

A `--show` option is available to display the current configuration.

Related to: https://github.com/Zerka30/KumaCompanion/issues/24